### PR TITLE
WrenSec Builds - Phase #1 (for forgerock-build-tools)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,14 @@
+export MAVEN_PACKAGE="forgerock-build-tools"
+export BINTRAY_PACKAGE="wrensec-build-tools"
+export JFROG_PACKAGE="org/forgerock/forgerock-build-tools/"
+
+package_accept_release_tag() {
+  local tag_name="${1}"
+  
+  if [ "${tag_name}" == "1.0.2-1" ]; then
+    echo "Skipping 1.0.2-1 since org.forgerock:forgerock-parent:pom:2.0.15 is missing."
+    return -1
+  else
+    return 0
+  fi
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS. All rights reserved.
+  Portions Copyright © 2017 Wren Security. All rights reserved.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -24,69 +25,60 @@
   <artifactId>forgerock-build-tools</artifactId>
   <version>1.0.3</version>
   <packaging>jar</packaging>
-  <name>ForgeRock Common Maven Build Tools</name>
+  <name>Wren Security Common Maven Build Tools</name>
   <description>
-    This module includes common infrastructure required for building ForgeRock
-    projects, comprising of TestNG listeners, Checkstyle configuration, etc.
+    This module includes common infrastructure required for building Wren
+    Security forks of ForgeRock projects, comprising of TestNG listeners,
+    Checkstyle configuration, etc.
   </description>
-  <url>http://commons.forgerock.org/forgerock-build-tools</url>
+  <url>http://wrensecurity.org</url>
+  <scm>
+    <url>https://github.com/WrenSecurity/wrensec-build-tools</url>
+    <connection>scm:git:git://github.com/WrenSecurity/wrensec-build-tools.git</connection>
+    <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-build-tools.git</developerConnection>
+  </scm>
   <licenses>
     <license>
       <name>CDDL 1.0</name>
       <url>http://www.opensource.org/licenses/CDDL-1.0</url>
       <comments>Common Development and Distribution License (CDDL) 1.0.
-      This license applies as indicated in the source files.</comments>
+        This license applies as indicated in the source files.</comments>
       <distribution>repo</distribution>
     </license>
     <license>
       <name>GNU LGPL 2.1</name>
       <url>http://opensource.org/licenses/LGPL-2.1</url>
       <comments>The GNU Lesser General Public License, version 2.1. This license
-      applies to the patch for the Checkstyle indentation checker
-      as indicated in the source files.</comments>
+        applies to the patch for the Checkstyle indentation checker
+        as indicated in the source files.</comments>
       <distribution>repo</distribution>
     </license>
   </licenses>
   <distributionManagement>
-    <site>
-      <id>community.internal.forgerock.com</id>
-      <name>ForgeRock Community</name>
-      <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-build-tools</url>
-    </site>
+    <snapshotRepository>
+      <id>bintray-wrensecurity-releases</id>
+      <name>Wren Security Snapshot Repository</name>
+      <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-build-tools/;publish=1</url>
+    </snapshotRepository>
+
+    <repository>
+      <id>bintray-wrensecurity-snapshots</id>
+      <name>Wren Security Release Repository</name>
+      <url>${forgerockDistMgmtReleasesUrl}/wrensec-build-tools/;publish=1</url>
+    </repository>
   </distributionManagement>
-  <scm>
-    <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-build-tools.git</connection>
-    <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-build-tools.git</developerConnection>
-    <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-build-tools/browse</url>
-  </scm>
-  <ciManagement>
-    <system>jenkins</system>
-    <url>http://builds.forgerock.org/job/Commons%20-%20ForgeRock%20Build%20Tools/</url>
-    <notifiers>
-      <notifier>
-        <type>mail</type>
-        <sendOnError>true</sendOnError>
-        <sendOnFailure>true</sendOnFailure>
-        <sendOnSuccess>false</sendOnSuccess>
-        <sendOnWarning>false</sendOnWarning>
-      </notifier>
-    </notifiers>
-  </ciManagement>
   <repositories>
     <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>http://maven.forgerock.org/repo/releases</url>
+      <id>bintray-wrensecurity-releases</id>
+      <name>Wren Security Release Repository</name>
+      <url>http://dl.bintray.com/wrensecurity/releases</url>
+
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-    </repository>
-    <repository>
-      <id>forgerock-snapshots-repository</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>http://maven.forgerock.org/repo/snapshots</url>
+
       <releases>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -56,22 +56,23 @@
   </licenses>
   <distributionManagement>
     <snapshotRepository>
-      <id>bintray-wrensecurity-releases</id>
+      <id>wrensecurity-snapshots</id>
       <name>Wren Security Snapshot Repository</name>
-      <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-build-tools/;publish=1</url>
+      <url>${forgerockDistMgmtSnapshotsUrl}</url>
     </snapshotRepository>
 
     <repository>
-      <id>bintray-wrensecurity-snapshots</id>
+      <id>wrensecurity-releases</id>
       <name>Wren Security Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}/wrensec-build-tools/;publish=1</url>
+      <url>${forgerockDistMgmtReleasesUrl}</url>
     </repository>
   </distributionManagement>
   <repositories>
+    <!-- Needed to retrieve parent POM -->
     <repository>
-      <id>bintray-wrensecurity-releases</id>
+      <id>wrensecurity-releases</id>
       <name>Wren Security Release Repository</name>
-      <url>http://dl.bintray.com/wrensecurity/releases</url>
+      <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
       <snapshots>
         <enabled>false</enabled>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- updates branding to call this Wren Security Build Tools instead of ForgeRock Build Tools.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.